### PR TITLE
[Matrix] fix travis ci debian build (wrong Kodi include dir) and reduce other build works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
   - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
   - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
-  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-addon-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,12 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
-      compiler: gcc
-    - os: linux
-      dist: xenial
-      sudo: required
       compiler: clang
     - os: linux
       dist: bionic
       sudo: required
       compiler: gcc
       env: DEBIAN_BUILD=true
-    - os: osx
-      osx_image: xcode10.2
 
 before_install:
   - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ env:
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: focal
       sudo: required
       compiler: clang
     - os: linux
-      dist: bionic
+      dist: focal
       sudo: required
       compiler: gcc
       env: DEBIAN_BUILD=true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a [Kodi](https://kodi.tv) WAV audio encoder add-on.
 
 #### CI Testing
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/audioencoder.wav.svg?branch=Matrix)](https://travis-ci.org/xbmc/audioencoder.wav/branches)
+[![Build Status](https://travis-ci.com/xbmc/audioencoder.wav.svg?branch=Matrix)](https://travis-ci.com/xbmc/audioencoder.wav/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audioencoder.wav?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=24&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audioencoder.wav/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudioencoder.wav/branches/)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)


### PR DESCRIPTION
As there becomes soon a switch to the travis-ci.com where have time limitations are the OSX build and Linux gcc build removed.

The Debian build stays and the Linux clang language build.
Them good to have as Jenkins not makes Debian build and the Linux build to check about another way to create addon.